### PR TITLE
Extended battery cluster

### DIFF
--- a/include/battery.hpp
+++ b/include/battery.hpp
@@ -37,11 +37,30 @@ int battery_sample(void);
  * monotonic decreasing within the sequence.
  */
 struct battery_level_point {
-	/** Remaining life at #lvl_mV. */
+	/** Remaining life at #lvl_mV. 
+	 * 100 % -> 10000 */
 	uint16_t lvl_pptt;
 
 	/** Battery voltage at #lvl_pptt remaining life. */
 	uint16_t lvl_mV;
+};
+
+/** Simple discharging curve for a typical CR2032 coin cell battery. 
+*
+* See https://github.com/stanvn/zigbee-plant-sensor/pull/4 
+*/
+static const struct battery_level_point discharge_curve[] = {
+	{10000, BATTERY_FULL_MV},
+	{9900, 3000},
+	{9800, 2900},
+	{9600, 2800},
+	{2100, 2700},
+	{1100, 2600},
+	{700, 2500},
+	{400, 2400},
+	{200, 2300},
+	{100, 2200},
+	{0, BATTERY_EMPTY_MV},
 };
 
 /** Calculate the estimated battery level based on a measured voltage.
@@ -56,7 +75,5 @@ struct battery_level_point {
  */
 unsigned int battery_level_pptt(unsigned int batt_mV,
 				const struct battery_level_point *curve);
-
-double battery_state_of_charge(unsigned int battery_voltage);
 
 #endif /* APPLICATION_BATTERY_H_ */

--- a/include/battery.hpp
+++ b/include/battery.hpp
@@ -55,4 +55,6 @@ struct battery_level_point {
 unsigned int battery_level_pptt(unsigned int batt_mV,
 				const struct battery_level_point *curve);
 
+double battery_state_of_charge(unsigned int battery_voltage);
+
 #endif /* APPLICATION_BATTERY_H_ */

--- a/include/battery.hpp
+++ b/include/battery.hpp
@@ -11,6 +11,8 @@
 #define BATTERY_THRESHOLD1_MV 2400
 #define BATTERY_THRESHOLD2_MV 2600
 #define BATTERY_THRESHOLD3_MV 2800
+#define BATTERY_FULL_MV       3100
+#define BATTERY_EMPTY_MV      2000
 
 /** Enable or disable measurement of the battery voltage.
  *

--- a/src/battery.cpp
+++ b/src/battery.cpp
@@ -257,22 +257,3 @@ unsigned int battery_level_pptt(unsigned int batt_mV,
 		  * (batt_mV - pb->lvl_mV)
 		  / (pa->lvl_mV - pb->lvl_mV));
 }
-
-double battery_state_of_charge(unsigned int battery_voltage) {
-	if (battery_voltage > BATTERY_FULL_MV)
-	{
-		return 100.0;
-	}
-	else if (battery_voltage < BATTERY_EMPTY_MV)
-	{
-		return 0.0;
-	}
-	else
-	{
-		/* This is a very simply 2-point linear interpolation as a first approach to approximate the value. There is room for improvement with a more sophisticated algorithm here. */
-		double soc = (battery_voltage - BATTERY_EMPTY_MV) / (BATTERY_FULL_MV - BATTERY_EMPTY_MV);
-
-		LOG_DBG("SOC: %f \%", soc);
-		return (soc * 100);
-	}
-}

--- a/src/battery.cpp
+++ b/src/battery.cpp
@@ -259,11 +259,20 @@ unsigned int battery_level_pptt(unsigned int batt_mV,
 }
 
 double battery_state_of_charge(unsigned int battery_voltage) {
-	const double full_v = 3400;
-	const double empty_v = 2000;
+	if (battery_voltage > BATTERY_FULL_MV)
+	{
+		return 100.0;
+	}
+	else if (battery_voltage < BATTERY_EMPTY_MV)
+	{
+		return 0.0;
+	}
+	else
+	{
+		/* This is a very simply 2-point linear interpolation as a first approach to approximate the value. There is room for improvement with a more sophisticated algorithm here. */
+		double soc = (battery_voltage - BATTERY_EMPTY_MV) / (BATTERY_FULL_MV - BATTERY_EMPTY_MV);
 
-	double soc = (battery_voltage - empty_v) / (full_v - empty_v);
-
-	LOG_DBG("SOC: %f \%", soc);
-	return (soc * 100);
+		LOG_DBG("SOC: %f \%", soc);
+		return (soc * 100);
+	}
 }

--- a/src/battery.cpp
+++ b/src/battery.cpp
@@ -257,3 +257,13 @@ unsigned int battery_level_pptt(unsigned int batt_mV,
 		  * (batt_mV - pb->lvl_mV)
 		  / (pa->lvl_mV - pb->lvl_mV));
 }
+
+double battery_state_of_charge(unsigned int battery_voltage) {
+	const double full_v = 3400;
+	const double empty_v = 2000;
+
+	double soc = (battery_voltage - empty_v) / (full_v - empty_v);
+
+	LOG_DBG("SOC: %f \%", soc);
+	return (soc * 100);
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -279,7 +279,7 @@ status_code_t update_battery_state(int32_t battery_mv){
       (zb_uint8_t *)1,
       ZB_FALSE);
 
-  uint8_t soc = (uint8_t)round(battery_state_of_charge(battery_mv) * 2);
+  uint8_t soc = (uint8_t)round(battery_level_pptt(battery_mv, discharge_curve) / 100 * 2);
 
   status = zb_zcl_set_attr_val(
       PLANT_SENSOR_ENDPOINT,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -262,6 +262,25 @@ status_code_t update_battery_state(int32_t battery_mv){
     LOG_ERR("Failed to set ZCL attribute: %d", status);
     return -status;
   }
+
+  status = zb_zcl_set_attr_val(
+      PLANT_SENSOR_ENDPOINT,
+      ZB_ZCL_CLUSTER_ID_POWER_CONFIG,
+      ZB_ZCL_CLUSTER_SERVER_ROLE,
+      ZB_ZCL_ATTR_POWER_CONFIG_BATTERY_SIZE_ID,
+      (zb_uint8_t *)ZB_ZCL_POWER_CONFIG_BATTERY_SIZE_CR2,
+      ZB_FALSE);
+
+  uint8_t soc = (uint8_t)round(battery_state_of_charge(battery_mv) * 2);
+
+  status = zb_zcl_set_attr_val(
+      PLANT_SENSOR_ENDPOINT,
+      ZB_ZCL_CLUSTER_ID_POWER_CONFIG,
+      ZB_ZCL_CLUSTER_SERVER_ROLE,
+      ZB_ZCL_ATTR_POWER_CONFIG_BATTERY_PERCENTAGE_REMAINING_ID,
+      (zb_uint8_t *)&soc,
+      ZB_FALSE);
+
   return STATUS_SUCCESS;
 
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -268,7 +268,15 @@ status_code_t update_battery_state(int32_t battery_mv){
       ZB_ZCL_CLUSTER_ID_POWER_CONFIG,
       ZB_ZCL_CLUSTER_SERVER_ROLE,
       ZB_ZCL_ATTR_POWER_CONFIG_BATTERY_SIZE_ID,
-      (zb_uint8_t *)ZB_ZCL_POWER_CONFIG_BATTERY_SIZE_CR2,
+      (zb_uint8_t *)ZB_ZCL_POWER_CONFIG_BATTERY_SIZE_OTHER,
+      ZB_FALSE);
+
+  status = zb_zcl_set_attr_val(
+      PLANT_SENSOR_ENDPOINT,
+      ZB_ZCL_CLUSTER_ID_POWER_CONFIG,
+      ZB_ZCL_CLUSTER_SERVER_ROLE,
+      ZB_ZCL_ATTR_POWER_CONFIG_BATTERY_QUANTITY_ID,
+      (zb_uint8_t *)1,
       ZB_FALSE);
 
   uint8_t soc = (uint8_t)round(battery_state_of_charge(battery_mv) * 2);
@@ -280,6 +288,11 @@ status_code_t update_battery_state(int32_t battery_mv){
       ZB_ZCL_ATTR_POWER_CONFIG_BATTERY_PERCENTAGE_REMAINING_ID,
       (zb_uint8_t *)&soc,
       ZB_FALSE);
+  
+  if (status) {
+    LOG_ERR("Failed to set ZCL attribute: %d", status);
+    return -status;
+  }
 
   return STATUS_SUCCESS;
 

--- a/src/zigbee.cpp
+++ b/src/zigbee.cpp
@@ -39,7 +39,7 @@ extern "C" {
       &dev_ctx.identify_attr.identify_time);
 
 
-  // Create Basic cluster attribute list
+  // Create basic cluster attribute list
   ZB_ZCL_DECLARE_BASIC_ATTRIB_LIST_EXT(
       basic_attr_list,
       &dev_ctx.basic_attr.zcl_version,
@@ -54,7 +54,7 @@ extern "C" {
       &dev_ctx.basic_attr.ph_env,
       dev_ctx.basic_attr.sw_ver);
 
-  // Create temperature measurement cluster attribure list
+  // Create temperature measurement cluster attribute list
   ZB_ZCL_DECLARE_TEMP_MEASUREMENT_ATTRIB_LIST(
       temp_measurement_attr_list,
       &dev_ctx.temp_measure_attrs.measure_value,
@@ -62,7 +62,7 @@ extern "C" {
       &dev_ctx.temp_measure_attrs.max_measure_value,
       &dev_ctx.temp_measure_attrs.tolerance);
 
-  // Create humidity measurement cluster attribure list
+  // Create humidity measurement cluster attribute list
   ZB_ZCL_DECLARE_REL_HUMIDITY_MEASUREMENT_ATTRIB_LIST(
       humidity_measurement_attr_list,
       &dev_ctx.humidity_measurement_attrs.measure_value,
@@ -70,7 +70,7 @@ extern "C" {
       &dev_ctx.humidity_measurement_attrs.max_measure_value
       );
 
-  // Create soil moistuer measurement cluster attribure list
+  // Create soil moisture measurement cluster attribure list
   ZB_ZCL_DECLARE_REL_HUMIDITY_MEASUREMENT_ATTRIB_LIST(
       soil_moisture_measurement_attr_list,
       &dev_ctx.soil_moisture_measurement_attrs.measure_value,
@@ -78,22 +78,31 @@ extern "C" {
       &dev_ctx.soil_moisture_measurement_attrs.max_measure_value
       );
 
-  // Create illuminance measurement cluster attribure list
+  // Create illuminance measurement cluster attribute list
   ZB_ZCL_DECLARE_ILLUMINANCE_MEASUREMENT_ATTRIB_LIST(
       illum_measure_attr_list,
       &dev_ctx.illum_attrs.measure_value,
       &dev_ctx.illum_attrs.min_measure_value,
       &dev_ctx.illum_attrs.max_measure_value);
 
-  // Create power configuration cluster attribure list
-  ZB_ZCL_DECLARE_POWER_CONFIG_ATTRIB_LIST(
+  // Create power configuration cluster attribute list
+  ZB_ZCL_DECLARE_POWER_CONFIG_BATTERY_ATTRIB_LIST_EXT(
       power_config_attr_list,
       &dev_ctx.power_config_attr.battery_voltage,
       &dev_ctx.power_config_attr.battery_size,
       &dev_ctx.power_config_attr.battery_quantity,
       &dev_ctx.power_config_attr.battery_rated_voltage,
       &dev_ctx.power_config_attr.battery_alarm_mask,
-      &dev_ctx.power_config_attr.battery_voltage_min_threshold
+      &dev_ctx.power_config_attr.battery_voltage_min_threshold,
+      &dev_ctx.power_config_attr.battery_percentage_remaining,
+      &dev_ctx.power_config_attr.battery_voltage_threshold1,
+      &dev_ctx.power_config_attr.battery_voltage_threshold2,
+      &dev_ctx.power_config_attr.battery_voltage_threshold3,
+      &dev_ctx.power_config_attr.battery_percentage_min_threshold,
+      &dev_ctx.power_config_attr.battery_percentage_threshold1,
+      &dev_ctx.power_config_attr.battery_percentage_threshold2,
+      &dev_ctx.power_config_attr.battery_percentage_threshold3,
+      &dev_ctx.power_config_attr.battery_alarm_state
       );
 
   // Declare the plant sensor endpoint cluster list
@@ -114,7 +123,7 @@ extern "C" {
       PLANT_SENSOR_ENDPOINT,
       plant_sensor_clusters);
 
-  // Attacht the app contect to the plant sensor endpoint
+  // Attacht the app context to the plant sensor endpoint
   ZBOSS_DECLARE_DEVICE_CTX_1_EP(app_sensor_ctx, plant_sensor_ep);
 
 


### PR DESCRIPTION
Enabling reporting of more advanced battery attributes.

This for example enables the correct display of battery percentage in Home Assistant via ZHA integration.

State of charge calculation is a first approach as a proof of concept.