### PR TITLE
Zha illumination compliance

### DIFF
--- a/src/light_sensor.cpp
+++ b/src/light_sensor.cpp
@@ -42,7 +42,7 @@ int32_t light_sensor_c::read(){
   // Reference values are based on the datasheet where the current at
   // 10000 lux should be 1500 uA
   const double lux_ref = 10000.0f;
-  const double current_ref = 1.5e-3f;
+  const double current_ref = 3.59e-3f;
 
   const double current = voltage / phototransistor_resistor;
   const uint16_t brightness = (uint16_t)MAX(0, MIN(lux_ref * current / current_ref, UINT16_MAX));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -195,8 +195,18 @@ status_code_t update_light_sensor(){
     LOG_ERR("Failed to read from light sensor");
     return -value;
   }
-  LOG_INF("Light: %d", value);
-  int16_t light_sensor_attribute = (int16_t)(10000.0 * log10(value));
+  LOG_INF("Light: %d lx", value);
+
+  int16_t light_sensor_attribute;
+  if (value >= 1)
+  {
+    light_sensor_attribute = (int16_t)(10000.0 * log10(value) + 1.0);
+  }
+  else
+  {
+    light_sensor_attribute = 0;
+  }
+  
   LOG_DBG("Light attribute: %d", light_sensor_attribute);
 
   zb_zcl_status_t status = zb_zcl_set_attr_val(


### PR DESCRIPTION
The ZHA spec is quite specific about the encoding of illuminance values and their valid value range.

This PR fixes the implementation to be compliant with the spec:

* Correct conversion via log and offset function
* Edge case handling of `0`, since log(0) is not defined

Reverting reference value for photo diode to original b-parasite value.