### PR TITLE
Fixing adc illuminance channel gain to include whole range measurments.

### DIFF
--- a/boards/b_parasite.overlay
+++ b/boards/b_parasite.overlay
@@ -37,7 +37,7 @@
 
   channel@1 {
     reg = <1>;
-    zephyr,gain = "ADC_GAIN_1";
+    zephyr,gain = "ADC_GAIN_1_6";
     zephyr,reference = "ADC_REF_INTERNAL";
     zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_MICROSECONDS, 20)>;
     zephyr,input-positive = <NRF_SAADC_AIN0>;


### PR DESCRIPTION
The gain was wrong and illuminance `mV` values where capped at 600mV (roughly `3500 lx`).

Changing the gain to a `1/6` as with the other channels fixes the readout.