### PR TITLE
Fix wrong variable name in zigbee2mqtt converter

### DIFF
--- a/zigbee2mqtt/plant_sensor.js
+++ b/zigbee2mqtt/plant_sensor.js
@@ -21,7 +21,7 @@ const definition = {
     await reporting.batteryPercentageRemaining(endpoint, overides);
     await reporting.temperature(endpoint, overides);
     await reporting.humidity(endpoint, overides);
-    await reporting.illuminance(firstEndpoint, overides);
+    await reporting.illuminance(endpoint, overides);
     await reporting.soil_moisture(endpoint, overides);
 
   },


### PR DESCRIPTION
`firstEndpoint` as a variable does not exist in this context here. This fixed it for me